### PR TITLE
feat: add domain templates and selection UI

### DIFF
--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { getTemplate } from "@/server/templates";
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const tmpl = getTemplate(params.id);
+  if (!tmpl) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json(tmpl);
+}

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+import { listTemplates } from "@/server/templates";
+
+export async function GET() {
+  return NextResponse.json({ templates: listTemplates() });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,6 +48,22 @@ export default function Home() {
   const [plan, setPlan] = useState<PlanResponse | null>(null);
   const [sim, setSim] = useState<SimResponse | null>(null);
   const [deploy, setDeploy] = useState<DeployResponse | null>(null);
+  const [templates, setTemplates] = useState<Array<{ id: string; label: string; desire: Desire }>>([]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch("/api/templates", { signal: controller.signal })
+      .then(res => res.json())
+      .then(data => setTemplates(data.templates || []))
+      .catch(() => {});
+    return () => controller.abort();
+  }, []);
+
+  function applyTemplate(id: string) {
+    const tmpl = templates.find((t) => t.id === id);
+    if (tmpl) setDesire(tmpl.desire);
+  }
+
 
   // Evals (Daytona) smoke-test state
   const [evalLanguage, setEvalLanguage] = useState<"python" | "typescript" | "javascript">("python");
@@ -237,6 +253,21 @@ export default function Home() {
                 Reset
               </button>
             </div>
+            {templates.length > 0 && (
+              <div className="mb-4">
+                <label className="text-sm text-foreground/70 mr-2">Template</label>
+                <select
+                  className="px-2 py-1 rounded-md border border-black/10 dark:border-white/15 bg-background/70 text-sm"
+                  defaultValue=""
+                  onChange={(e) => applyTemplate(e.target.value)}
+                >
+                  <option value="">Custom</option>
+                  {templates.map((t) => (
+                    <option key={t.id} value={t.id}>{t.label}</option>
+                  ))}
+                </select>
+              </div>
+            )}
             <div className="grid sm:grid-cols-2 gap-4">
               <div>
                 <label className="text-sm text-foreground/70">Goal</label>

--- a/src/server/templates.ts
+++ b/src/server/templates.ts
@@ -1,0 +1,175 @@
+export type AppTemplate = {
+  id: string
+  label: string
+  desire: { goal: string; constraints: string[]; outputs: string[] }
+  spec: {
+    identity: {
+      purpose: string
+      beneficiaries: string[]
+      safety_envelope: string[]
+    }
+    desire: { goal: string; constraints: string[]; outputs: string[] }
+    data_contracts: { entities: { name: string; fields: string[] }[] }
+    workflows: { pipelines: { name: string; steps: string[] }[] }
+    interface: { panels: string[] }
+  }
+}
+
+const templates: AppTemplate[] = [
+  {
+    id: "law",
+    label: "Law Practitioners (US/UK)",
+    desire: {
+      goal: "Track statutes, regulations, and case law in a specialty",
+      constraints: ["US and UK jurisdictions"],
+      outputs: ["matter brief", "precedent digest", "filing checklist", "risk memo"],
+    },
+    spec: {
+      identity: {
+        purpose: "Monitor legal updates and produce client-ready analyses",
+        beneficiaries: ["Attorney", "Paralegal", "Client"],
+        safety_envelope: ["Not legal advice", "Verify citations"],
+      },
+      desire: {
+        goal: "Track statutes, regulations, and case law in a specialty",
+        constraints: ["US and UK jurisdictions"],
+        outputs: ["matter brief", "precedent digest", "filing checklist", "risk memo"],
+      },
+      data_contracts: {
+        entities: [
+          { name: "Statute", fields: ["citation", "jurisdiction", "summary", "effective_date"] },
+          { name: "Regulation", fields: ["citation", "agency", "summary", "updated"] },
+          { name: "CaseLaw", fields: ["title", "citation", "holding", "jurisdiction"] },
+        ],
+      },
+      workflows: {
+        pipelines: [
+          {
+            name: "Legal update tracker",
+            steps: ["Fetch updates", "Classify by topic", "Summarize implications", "Generate checklist"],
+          },
+        ],
+      },
+      interface: { panels: ["Matter Brief", "Precedent Digest", "Checklist Composer", "Risk Memo"] },
+    },
+  },
+  {
+    id: "farm",
+    label: "Small Farms & Growers",
+    desire: {
+      goal: "Turn weather, pest alerts, cultivar research, and market signals into crop plans",
+      constraints: ["organic practices"],
+      outputs: ["planting calendar", "pruning schedule", "pest treatment plan", "market-day pricing"],
+    },
+    spec: {
+      identity: {
+        purpose: "Assist growers with planning and market decisions",
+        beneficiaries: ["Farmer", "Field Manager"],
+        safety_envelope: ["No pesticide recommendations without label"],
+      },
+      desire: {
+        goal: "Turn weather, pest alerts, cultivar research, and market signals into crop plans",
+        constraints: ["organic practices"],
+        outputs: ["planting calendar", "pruning schedule", "pest treatment plan", "market-day pricing"],
+      },
+      data_contracts: {
+        entities: [
+          { name: "Weather", fields: ["date", "temp_high", "temp_low", "precip"] },
+          { name: "Alert", fields: ["type", "severity", "crop"] },
+          { name: "MarketPrice", fields: ["crop", "price", "market_day"] },
+        ],
+      },
+      workflows: {
+        pipelines: [
+          {
+            name: "Crop plan generator",
+            steps: ["Ingest signals", "Assess risk", "Update calendars", "Recommend actions"],
+          },
+        ],
+      },
+      interface: { panels: ["Planting Calendar", "Pest Treatments", "Input Notes", "Pricing Cheatsheet"] },
+    },
+  },
+  {
+    id: "culinary",
+    label: "Culinary Professionals / Dietitians",
+    desire: {
+      goal: "Track allergen alerts and nutrition research; tailor menus to client constraints",
+      constraints: ["dietary restrictions"],
+      outputs: ["menu plan", "substitution matrix", "nutrition summary"],
+    },
+    spec: {
+      identity: {
+        purpose: "Plan menus that respect allergens and nutritional goals",
+        beneficiaries: ["Chef", "Dietitian", "Client"],
+        safety_envelope: ["Verify allergen information"],
+      },
+      desire: {
+        goal: "Track allergen alerts and nutrition research; tailor menus to client constraints",
+        constraints: ["dietary restrictions"],
+        outputs: ["menu plan", "substitution matrix", "nutrition summary"],
+      },
+      data_contracts: {
+        entities: [
+          { name: "Ingredient", fields: ["name", "allergens", "nutrition"] },
+          { name: "Alert", fields: ["ingredient", "issue", "date"] },
+          { name: "MenuItem", fields: ["title", "ingredients", "calories"] },
+        ],
+      },
+      workflows: {
+        pipelines: [
+          {
+            name: "Menu planner",
+            steps: ["Gather alerts", "Match client profile", "Suggest substitutions", "Summarize nutrition"],
+          },
+        ],
+      },
+      interface: { panels: ["Menu Plan", "Substitution Matrix", "Nutrition Summary"] },
+    },
+  },
+  {
+    id: "immigration",
+    label: "Immigration / Compliance Advisors",
+    desire: {
+      goal: "Monitor policy changes and case law; generate client checklists and timelines",
+      constraints: ["current regulations"],
+      outputs: ["eligibility matrix", "document checklist", "milestone plan"],
+    },
+    spec: {
+      identity: {
+        purpose: "Assist advisors with immigration and compliance planning",
+        beneficiaries: ["Advisor", "Client"],
+        safety_envelope: ["Not legal advice", "Verify filing deadlines"],
+      },
+      desire: {
+        goal: "Monitor policy changes and case law; generate client checklists and timelines",
+        constraints: ["current regulations"],
+        outputs: ["eligibility matrix", "document checklist", "milestone plan"],
+      },
+      data_contracts: {
+        entities: [
+          { name: "PolicyUpdate", fields: ["jurisdiction", "summary", "effective_date"] },
+          { name: "CaseDecision", fields: ["citation", "holding", "jurisdiction"] },
+          { name: "Client", fields: ["name", "status", "country"] },
+        ],
+      },
+      workflows: {
+        pipelines: [
+          {
+            name: "Compliance tracker",
+            steps: ["Collect updates", "Assess eligibility", "Generate checklist", "Plan milestones"],
+          },
+        ],
+      },
+      interface: { panels: ["Eligibility Matrix", "Document Checklist", "Milestone Plan"] },
+    },
+  },
+]
+
+export function listTemplates() {
+  return templates
+}
+
+export function getTemplate(id: string) {
+  return templates.find((t) => t.id === id)
+}


### PR DESCRIPTION
## Summary
- add structured templates for law, farming, culinary and immigration domains
- expose template list and lookup API routes
- allow users to select a template in the desire step

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any...)*
- `npx eslint src/server/templates.ts src/app/api/templates/route.ts src/app/api/templates/[id]/route.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c7384c8d08832e9a9684591fc9ccce